### PR TITLE
Add resize option for inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This template uses transfer-learning from Fully Convolutional Network or DeepLab
 - Allow only 1 training dataset and 1 validation dataset
 
 
-## Parameters
+## Training Parameters
 | env | type | required | default | description |
 | --- | --- | --- | --- | --- |
 | BATCH_SIZE | int | true | 32 | Batch size. |
@@ -40,6 +40,12 @@ This template uses transfer-learning from Fully Convolutional Network or DeepLab
 | EARLY_STOPPING_TEST_SIZE | float | false | 0.2 | Test data size for "Early stopping". Need to be from `0.0` to `1.0`. |
 | RESUME | str | false | None | Filepath. Set if you want to use pretrained your model. |
 | AUX_LOSS | bool | false | false | Set if you want to use aux loss. |
+
+## Inference Parameters
+| env | type | required | default | description |
+| --- | --- | --- | --- | --- |
+| RESIZE_TO_ORIGINAL | bool | true | false | Resize to the size of input image. Default is false, image size is the same as training. |
+| DEVICE | string | true | cuda | Device name to use: "cuda" or "cpu". |
 
 ### TBD
 Distributed mode is being developed.

--- a/parameters.py
+++ b/parameters.py
@@ -51,6 +51,9 @@ elif 'SLURM_PROCID' in os.environ:
 else:
     DISTRIBUTED = False
 
+# inference
+RESIZE_TO_ORIGINAL = bool(os.environ.get('RESIZE_TO_ORIGINAL','False').lower() == 'true')
+
 # For print
 parameters = {
     'BATCH_SIZE': BATCH_SIZE,


### PR DESCRIPTION
## What is this PR for?

Add `RESIZE_TO_ORIGINAL` option for inference.
Currently we resize the input image to fit the model and return the raw result. But some users want to use the result with the same size of input image.

## This PR includes

- Add `RESIZE_TO_ORIGINAL` option for inference.

## What type of PR is it?

Feature

## What is the issue?

N/A

## How should this be tested?

N/A